### PR TITLE
Add missing include

### DIFF
--- a/mclib/include/mclib/block/Block.h
+++ b/mclib/include/mclib/block/Block.h
@@ -6,6 +6,7 @@
 
 #include <unordered_map>
 #include <string>
+#include <vector>
 
 namespace mc {
 namespace block {


### PR DESCRIPTION
Header file references std::vector but it is not included; this caused an error during build on my PC.